### PR TITLE
support HTTP source for error

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,12 +145,12 @@ Parser.prototype._handleError = function _handleError(line) {
       .replace(')', '');
 
       var values = msg.split(':');
-
+      var file = values.slice(0, values.length-2).join(':');
 
       msg = {
-        file: values[0],
-        line: values[1],
-        character: values[2]
+        file: file,
+        line: values[values.length-2],
+        character: values[values.length-1]
       };
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -417,3 +417,43 @@ test('generic output', function (t) {
   });
   p.end();
 });
+
+test('handles HTTP error source', function (t) {
+
+  t.plan(1);
+
+  var mockTap = [
+    "TAP version 13",
+    "# is true",
+    "ok 1 true value",
+    "ok 2 true value",
+    "not ok 3 strings match",
+    "  ---",
+    "    operator: equal",
+    "    expected: 'you'",
+    "    actual:   'me'",
+    "    at: Test.<anonymous> (http://localhost:9966/index.js:8:5)",
+    "  ...",
+    "not ok 15 plan != count",
+    "  ---",
+    "    operator: fail",
+    "    expected: 4",
+    "    actual:   3",
+    "  ...",
+    "",
+    "1..15",
+  ];
+
+  var p = parser();
+
+  p.on('output', function (output) {
+    var assert = output.fail[0];
+    t.deepEqual(assert.error.at, { character: '5', file: 'http://localhost:9966/index.js', line: '8' });
+  });
+
+  mockTap.forEach(function (line) {
+
+    p.write(line + '\n');
+  });
+  p.end();
+});


### PR DESCRIPTION
I'm working on some [browser based tap tools](https://github.com/Jam3/tap-dev-tool) and tap-parser has a hard time parsing errors that come from a URL like this:

```
http://localhost:9966/bundle.js:20:5
```

The `at: ...` field gets messed since it just splits on `':'`.

This PR fixes it without breaking the existing tests. If you have a better approach (i.e. using regexes or something) I'm all ears. :smile:
