### PR TITLE
Use PassThrough stream instead of through2

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var through = require('through2');
+var PassThrough = require('readable-stream/passthrough');
 var split = require('split');
 var trim = require('trim');
 var util = require('util');
@@ -175,7 +175,7 @@ module.exports = function (done) {
 
   done = done || function () {};
 
-  var stream = through();
+  var stream = new PassThrough();
   var parser = Parser();
   reemit(parser, stream, [
     'test', 'assert', 'version', 'result', 'pass', 'fail', 'comment'

--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
   "license": "MIT",
   "dependencies": {
     "re-emitter": "^1.0.0",
+    "readable-stream": "^2.0.0",
     "split": "^1.0.0",
-    "through2": "^0.6.3",
     "trim": "0.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "trim": "0.0.1"
   },
   "devDependencies": {
-    "tap-spec": "2.1.1",
+    "tap-spec": "4.0.0",
     "tape": "^4.0.0"
   },
   "directories": {


### PR DESCRIPTION
We don’t need to use [through2](https://github.com/rvagg/through2) in this case. We can use just a bare [PassThrough stream](https://nodejs.org/api/stream.html#stream_class_stream_passthrough) directly.

I introduced [readable-stream](https://github.com/nodejs/readable-stream) module for more compatibility, instead of using the built-in `stream`. (ref: [Why I don't use Node's core 'stream' module](http://r.va.gg/2014/06/why-i-dont-use-nodes-core-stream-module.html))
