### PR TITLE
emit test plans

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,7 @@ function Parser() {
     versions: [],
     results: [],
     comments: [],
+    plans: [],
     pass: [],
     fail: [],
   };
@@ -184,7 +185,7 @@ module.exports = function (done) {
   var stream = new PassThrough();
   var parser = Parser();
   reemit(parser, stream, [
-    'test', 'assert', 'version', 'result', 'pass', 'fail', 'comment'
+    'test', 'assert', 'version', 'result', 'pass', 'fail', 'comment', 'plan'
   ]);
 
   stream

--- a/lib/parse-line.js
+++ b/lib/parse-line.js
@@ -17,4 +17,8 @@ module.exports = function (line) {
   if (types.is('test', line)) {
     return types.test(line);
   }
+
+  if (types.is('plan', line)) {
+    return types.plan(line);
+  }
 };

--- a/lib/plan.js
+++ b/lib/plan.js
@@ -1,0 +1,17 @@
+var expr = require('./utils/regexes');
+
+var exports = module.exports = function (line) {
+  var m = expr.plan.exec(line);
+  return {
+    type: 'plan',
+    raw: line,
+    from: m[1] && Number(m[1]),
+    to: m[2] && Number(m[2]),
+    skip: m[3]
+  };
+};
+
+exports.equals = function (line) {
+
+  return expr.plan.test(line);
+};

--- a/lib/types.js
+++ b/lib/types.js
@@ -3,6 +3,7 @@ var types = module.exports = {
   assert: require('./assert'),
   test: require('./test'),
   version: require('./version'),
+  plan: require('./plan'),
   is: function (type, line) {
     
     var type = types[type];

--- a/test/index.js
+++ b/test/index.js
@@ -8,7 +8,8 @@ test('output event', function (t) {
   var mockTap = [
     '# is true',
     'ok 1 true value',
-    'ok 2 true value'
+    'ok 2 true value',
+    '1..2'
   ];
 
   var p = parser();
@@ -30,7 +31,8 @@ test('output event', function (t) {
         { name: 'is true', number: 1, raw: '# is true', type: 'test' }
       ],
       versions: [],
-      comments: []
+      comments: [],
+      plans: [{ from: 1, to: 2, raw: '1..2', skip: undefined, type: 'plan' }]
     }, 'output data');
   });
 
@@ -48,7 +50,8 @@ test('output callback', function (t) {
   var mockTap = [
     '# is true',
     'ok 1 true value',
-    'ok 2 true value'
+    'ok 2 true value',
+    '1..2'
   ];
 
   var p = parser(function (err, output) {
@@ -68,7 +71,8 @@ test('output callback', function (t) {
         { name: 'is true', number: 1, raw: '# is true', type: 'test' }
       ],
       versions: [],
-      comments: []
+      comments: [],
+      plans: [{ from: 1, to: 2, raw: '1..2', skip: undefined, type: 'plan' }]
     }, 'output data');
   });
 
@@ -354,6 +358,31 @@ test('failed assertion', function (t) {
   p.on('fail', function (fail) {
 
     fails.push(fail);
+  });
+
+  mockTap.forEach(function (line) {
+
+    p.write(line + '\n');
+  });
+  p.end();
+});
+
+test('plan', function (t) {
+
+  var mockTap = [
+    '1..2',
+  ];
+
+  var plans = [];
+  var p = parser(function () {
+    t.deepEqual(plans, [
+      { from: 1, to: 2, raw: '1..2', skip: undefined, type: 'plan' }
+    ]);
+    t.end();
+  });
+
+  p.on('plan', function (plan) {
+    plans.push(plan);
   });
 
   mockTap.forEach(function (line) {


### PR DESCRIPTION
Related: https://github.com/scottcorgan/tap-spec/issues/40

@scottcorgan 

I've searched high and low, and can not find a way to determine the exit code of the process piping data to stdinn. I am not sure it exists (I know it does in bash shell, but it does not seem to at the OS level).

The way other tap reporters (i.e. faucet) seem to handle this, is that they look for the plan line (which, as I understand it is required), and then compare what they get.

This implements recognition of the plan line:

```
1...3
```

And emits it as an event.

This will allow you to correctly exit with your other reporters. Thanks!