### PR TITLE
Provide tap errors in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,19 @@ $ something-that-produces-tap | tap-out
     { name: 'is true', number: 1, raw: '# is true', type: 'test' }
   ],
   asserts: [
-    { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' }, 
-    { name: 'true value', number: 2, ok: true, raw: 'ok 2 true value', test: 1, type: 'assert' }
-  ],
-  results: [],
-  versions: [],
-  comments: [],
-  fail: [],
-  pass: [ 
     { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' },
     { name: 'true value', number: 2, ok: true, raw: 'ok 2 true value', test: 1, type: 'assert' }
   ],
+  versions: [],
+  results: [],
+  comments: [],
+  plans: [{ type: 'plan', raw: '1..2', from: 1, to: 2, skip: false }],
+  pass: [
+    { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' },
+    { name: 'true value', number: 2, ok: true, raw: 'ok 2 true value', test: 1, type: 'assert' }
+  ],
+  fail: [],
+  errors: []
 }
 ```
 
@@ -39,7 +41,7 @@ $ something-that-produces-tap | tap-out
 var tapOut = require('tap-out');
 
 var t = tapOut(function (output) {
-  
+
   console.log(output);
 });
 
@@ -71,14 +73,14 @@ Example output
     { name: 'is true', number: 1, raw: '# is true', type: 'test' }
   ],
   asserts: [
-    { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' }, 
+    { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' },
     { name: 'true value', number: 2, ok: true, raw: 'ok 2 true value', test: 1, type: 'assert' }
   ],
   results: [],
   versions: [],
   comments: [],
   fail: [],
-  pass: [ 
+  pass: [
     { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' },
     { name: 'true value', number: 2, ok: true, raw: 'ok 2 true value', test: 1, type: 'assert' }
   ],
@@ -155,7 +157,7 @@ Tests
   count: '15',
   name: 'tests',
   raw: '# tests 15',
-  type: 'result' 
+  type: 'result'
 }
 ```
 
@@ -195,7 +197,7 @@ Generic output like `console.log()` in your tests.
 
 * `type` - this will always be `comment`
 * `raw` - the raw output before it was parsed
-* `test` - the nubmer of the test this comment belongs to
+* `test` - the number of the test this comment belongs to
 
 ```js
 {

--- a/lib/error.js
+++ b/lib/error.js
@@ -1,0 +1,6 @@
+module.exports = function (message) {
+  return {
+    type: 'error',
+    message: message
+  };
+};

--- a/test/index.js
+++ b/test/index.js
@@ -32,7 +32,8 @@ test('output event', function (t) {
       ],
       versions: [],
       comments: [],
-      plans: [{ from: 1, to: 2, raw: '1..2', skip: undefined, type: 'plan' }]
+      plans: [{ from: 1, to: 2, raw: '1..2', skip: undefined, type: 'plan' }],
+      errors: []
     }, 'output data');
   });
 
@@ -72,7 +73,8 @@ test('output callback', function (t) {
       ],
       versions: [],
       comments: [],
-      plans: [{ from: 1, to: 2, raw: '1..2', skip: undefined, type: 'plan' }]
+      plans: [{ from: 1, to: 2, raw: '1..2', skip: undefined, type: 'plan' }],
+      errors: []
     }, 'output data');
   });
 
@@ -560,6 +562,91 @@ test('handles multiline error string with |-', function (t) {
     var assert = output.fail[0];
     t.equal(assert.error.expected, '{ a: 1, b: 2 }');
     t.equal(assert.error.actual, '{ a: 1, b: 3 }');
+  });
+
+  mockTap.forEach(function (line) {
+    p.write(line + '\n');
+  });
+  p.end();
+
+});
+
+test('output without plan', function (t) {
+
+  t.plan(1);
+
+  var mockTap = [
+    "# is true",
+    "ok 1 true value",
+  ];
+
+  var p = parser();
+
+  p.on('output', function (output) {
+
+    t.deepEqual(output, {
+      asserts: [
+        { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' }
+      ],
+      fail: [],
+      pass: [
+        { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' }
+      ],
+      results: [],
+      tests: [
+        { name: 'is true', number: 1, raw: '# is true', type: 'test' }
+      ],
+      versions: [],
+      comments: [],
+      plans: [],
+      errors: [
+        { message: 'no plan provided', type: 'error' }
+      ]
+    }, 'output data with empty plans and no plan provided');
+  });
+
+  mockTap.forEach(function (line) {
+    p.write(line + '\n');
+  });
+  p.end();
+
+});
+
+test('output with assert count and plan mismatch', function (t) {
+
+  t.plan(1);
+
+  var mockTap = [
+    "# is true",
+    "ok 1 true value",
+    "1..2",
+  ];
+
+  var p = parser();
+
+  p.on('output', function (output) {
+
+    t.deepEqual(output, {
+      asserts: [
+        { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' }
+      ],
+      fail: [],
+      pass: [
+        { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' }
+      ],
+      results: [],
+      tests: [
+        { name: 'is true', number: 1, raw: '# is true', type: 'test' }
+      ],
+      versions: [],
+      comments: [],
+      plans: [
+        { from: 1, to: 2, raw: '1..2', skip: undefined, type: 'plan' }
+      ],
+      errors: [
+        { message: 'incorrect number of assertions made', type: 'error' }
+      ]
+    }, 'output data with empty assert count and plan mismatch error');
   });
 
   mockTap.forEach(function (line) {

--- a/test/index.js
+++ b/test/index.js
@@ -655,3 +655,50 @@ test('output with assert count and plan mismatch', function (t) {
   p.end();
 
 });
+
+test('output with plan end and assertion number mismatch', function (t) {
+
+  t.plan(1);
+
+  var mockTap = [
+    "# is true",
+    "ok 1 true value",
+    'ok 3 true value',
+    "1..2",
+  ];
+
+  var p = parser();
+
+  p.on('output', function (output) {
+
+    t.deepEqual(output, {
+      asserts: [
+        { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' },
+        { name: 'true value', number: 3, ok: true, raw: 'ok 3 true value', test: 1, type: 'assert' }
+      ],
+      fail: [],
+      pass: [
+        { name: 'true value', number: 1, ok: true, raw: 'ok 1 true value', test: 1, type: 'assert' },
+        { name: 'true value', number: 3, ok: true, raw: 'ok 3 true value', test: 1, type: 'assert' }
+      ],
+      results: [],
+      tests: [
+        { name: 'is true', number: 1, raw: '# is true', type: 'test' }
+      ],
+      versions: [],
+      comments: [],
+      plans: [
+        { from: 1, to: 2, raw: '1..2', skip: undefined, type: 'plan' }
+      ],
+      errors: [
+        { message: 'last assertion number does not equal the plan end', type: 'error' }
+      ]
+    }, 'output data with plan end error');
+  });
+
+  mockTap.forEach(function (line) {
+    p.write(line + '\n');
+  });
+  p.end();
+
+});


### PR DESCRIPTION
:bug:  There are there are no errors with parsing the tap input, however the resulting output indicates that there was a problem.

- Tap output with no plan statement indicates that a problem
   -  _probably that the tap runner died silently in the middle of its run_
- Tap output where there number planned assertions does not match the actual number of assertions executed indicates that a problem
   - _could still be due that the tap runner died silently in the middle of its run_
   - _could be that more assertions were made than were planned, indicating a failure_
   - _possibly an assertion was never reached, which was intended to be reached_

## Description

:gear: Rather that expecting a consumer of the library to check for these edge cases themselves, I propose that we provide a mechanism for outputting errors.  This means that as a consumer, a successful data record from tap output is one with no errors and no fail assertions.

:new: The work done when the pull request has been raised, has been designed to be new feature with no breaking changes. 

:speaking_head: Because there has not been much dialogue about how to solve this problem, I am open for this to PR to be a place discussion and to bounce ideas off one another.

## Motivation and Context

The problem I am trying to solve has been discussed on GH issue <https://github.com/scottcorgan/tap-out/issues/26>.

## How Was This Tested?

:traffic_light:  Initially the testing I have done is with sample tap output files.  As commits were made, the tests were updated to cover the relevant cases

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change follows the style of this project
    - _as far as I can tell_
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed