### PR TITLE
emit fail when no fail diagnostics

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -294,12 +294,15 @@ test('failed assertion', function (t) {
     "    actual:   'me'",
     "    at: Test.<anonymous> (/Users/scott/www/divshot/divshot-cli/test/index.js:8:5)",
     "  ...",
-    "not ok 15 plan != count",
+    "not ok 4 plan != count",
     "  ---",
     "    operator: fail",
     "    expected: 4",
     "    actual:   3",
     "  ...",
+    "ok 5 true value",
+    "not ok 6 - failure",
+    "not ok 15 - item not found",
     "",
     "1..15",
   ];
@@ -346,11 +349,29 @@ test('failed assertion', function (t) {
             ].join('\n')
           },
           name: 'plan != count',
-          number: 15,
+          number: 4,
           ok: false,
-          raw: 'not ok 15 plan != count',
+          raw: 'not ok 4 plan != count',
           test: 1,
           type: 'plan'
+        },
+        {
+          error: { actual: undefined, expected: undefined, operator: undefined, at: undefined },
+          name: 'failure',
+          number: 6,
+          ok: false,
+          raw: 'not ok 6 - failure',
+          test: 1,
+          type: 'assert'
+        },
+        {
+          error: { actual: undefined, expected: undefined, operator: undefined, at: undefined },
+          name: 'item not found',
+          number: 15,
+          ok: false,
+          raw: 'not ok 15 - item not found',
+          test: 1,
+          type: 'assert'
         }
       ],
       'fails'


### PR DESCRIPTION
The fail event should be emitted when an assertion failed, regardless of whether the failed assertion in the tap output contains diagnostic data or not.

## Description

Updated line error handling to ensure that fail event is also emitted when no failure diagnostics provided.

```
1..4
# is true
ok 1 - Input file opened
not ok 2 - First line of the input valid
ok 3 - Read the rest of the file
not ok 4 - Summarized correctly
```

## Motivation and Context

I was looking into the root cause of a [GH issue reported in tap-teamcity](https://github.com/smockle/tap-teamcity/issues/11).  This library expects the "fail" event to be emitted on an assertion fail, but when tap does no provide any failure diagnostics this event is not present.

## How Was This Tested?
Updated unit tests and tested output with the tap output above.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My change follows the style of this project
    - _as far as I can tell_
- [x] My change requires a change to the documentation
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests passed