### PR TITLE
Raw error with stack

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,6 +121,7 @@ Parser.prototype._handleError = function _handleError(line) {
 
     if (this.tmpErrorOutput) {
       lastAssert.error.stack = this.tmpErrorOutput;
+      this.lastAsserRawErrorString += this.tmpErrorOutput + '\n';
       this.tmpErrorOutput = '';
     }
 

--- a/test/index.js
+++ b/test/index.js
@@ -571,6 +571,64 @@ test('handles multiline error string with |-', function (t) {
 
 });
 
+test('handles multiline error stack with |-', function (t) {
+
+  t.plan(2);
+
+  var mockTap = [
+    "TAP version 13",
+    "# promise error",
+    "not ok 1 TypeError: foo",
+    "  ---",
+    "    operator: error",
+    "    expected: |-",
+    "      undefined",
+    "    actual: |-",
+    "      [TypeError: foo]",
+    "    at: process._tickCallback (internal/process/next_tick.js:103:7)",
+    "    stack: |-",
+    "      TypeError: foo",
+    "          at throwError (/Users/germ/Projects/a/b/test.js:17:9)",
+    "          at Promise.resolve.then (/Users/germ/Projects/a/b/test.js:24:5)",
+    "          at process._tickCallback (internal/process/next_tick.js:103:7)",
+    "  ...",
+    "",
+    "1..1",
+    "# tests 1",
+    "# pass  0",
+    "# fail  1"
+  ];
+
+  var p = parser();
+
+  p.on('output', function (output) {
+    var assert = output.fail[0];
+    t.equal(assert.error.stack, 'TypeError: foo\n'
+      + 'at throwError (/Users/germ/Projects/a/b/test.js:17:9)\n'
+      + 'at Promise.resolve.then (/Users/germ/Projects/a/b/test.js:24:5)\n'
+      + 'at process._tickCallback (internal/process/next_tick.js:103:7)\n'
+    );
+    t.equal(assert.error.raw, '    operator: error\n'
+      + '    expected: |-\n'
+      + '      undefined\n'
+      + '    actual: |-\n'
+      + '      [TypeError: foo]\n'
+      + '    at: process._tickCallback (internal/process/next_tick.js:103:7)\n'
+      + '    stack: |-\n'
+      + 'TypeError: foo\n'
+      + 'at throwError (/Users/germ/Projects/a/b/test.js:17:9)\n'
+      + 'at Promise.resolve.then (/Users/germ/Projects/a/b/test.js:24:5)\n'
+      + 'at process._tickCallback (internal/process/next_tick.js:103:7)'
+    );
+  });
+
+  mockTap.forEach(function (line) {
+    p.write(line + '\n');
+  });
+  p.end();
+
+});
+
 test('output without plan', function (t) {
 
   t.plan(1);


### PR DESCRIPTION
Please review. I am not sure if the stack and the raw should just contain the whole stack as multiline string.

This change should allow tap-spec to display the error stack, reported here 
https://github.com/substack/tape/issues/365
https://github.com/scottcorgan/tap-spec/issues/53

For testing there is a fork of tap-spec at `thisconnect/tap-spec` that uses my modified tap-out at `thisconnect/tap-out#raw-with-stack`. Current tap-spec uses an old version of tap-out. But tap-out 2.0.0 seems to work fine with tap-spec. `thisconnect/tap-out#raw-with-stack` is based on 2.0.0

```
npm i --save-dev thisconnect/tap-spec
tape yourtests.js | tap-spec
```
you should see the stack error

for testing an error stack I used

```javascript
function throwError(){
  throw new TypeError('foo')
}

tape('promise error', (t) => {
  Promise.resolve()
  .then(() => {
    throwError()
  })
  .then(() => t.end())
  .catch(t.end) // we want the stack info here
})
```