### PR TITLE
tighten up result line regex to avoid misclassification

### DIFF
--- a/lib/result.js
+++ b/lib/result.js
@@ -18,7 +18,7 @@ var exports = module.exports = function (line) {
 
 exports.equals = function (line) {
   
-  var p = new RegExp('(#)(\\s+)((?:[a-z][a-z]+))(\\s+)(\\d+)',['i']);
+  var p = new RegExp('#\\s+(tests|pass|fail|todo)\\s+\\d+\\s*$',['i']);
   
   return p.test(line);
 };

--- a/test/index.js
+++ b/test/index.js
@@ -781,3 +781,59 @@ test('output with plan end and assertion number mismatch', function (t) {
   p.end();
 
 });
+
+test('results with test containing #+word+number', function(t) {
+  t.plan(4);
+
+  var mockTap = [
+    '# word 7',
+    '# tests 15',
+    '# pass  13',
+    '# fail  2'
+  ];
+
+  var p = parser();
+
+  var results = [];
+  p.on('result', function (result) {
+    results.push(result);
+  });
+
+  p.on('test', function (test) {
+    t.deepEqual(test, {
+      type: 'test',
+      name: 'word 7',
+      raw: '# word 7',
+      number: 1
+    }, 'test is parsed');
+  })
+
+  p.on('output', function () {
+    t.deepEqual(results[0], {
+      count: '15',
+      name: 'tests',
+      raw: '# tests 15',
+      type: 'result'
+    }, 'tests');
+
+    t.deepEqual(results[1], {
+      count: '13',
+      name: 'pass',
+      raw: '# pass  13',
+      type: 'result'
+    }, 'pass');
+
+    t.deepEqual(results[2], {
+      count: '2',
+      name: 'fail',
+      raw: '# fail  2',
+      type: 'result'
+    }, 'fail');
+  });
+
+  mockTap.forEach(function (line) {
+    p.write(line + '\n');
+  });
+  
+  p.end();
+});


### PR DESCRIPTION
This PR strictly limits the result regexp to only those output by tape according to [the specification](https://github.com/substack/tape/blob/master/lib/results.js#L139-L142) (`# tests`, `# pass`, `# fail`, and `# todo`).  The case it fixes is the mis-classification of test names that start with a word followed by a number, eg:

```
test('version 3.x should do this thing', spec => {})
```

In the above case, tape outputs `# version 3.x should do this thing`, however tap-out treats this as a result instead of a test due to a fairly lax regexp, causing the test name to not be output.  

A test replicating the behavior is included.  