### PR TITLE
Loosen trim version pinning in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "re-emitter": "1.1.3",
     "readable-stream": "2.2.9",
     "split": "1.0.0",
-    "trim": "0.0.1"
+    "trim": "^0.0.1"
   },
   "devDependencies": {
     "tape": "4.6.3"


### PR DESCRIPTION
To not get in the way of users of tap-out (e.g. via tap-spec) patching their way past https://github.com/advisories/GHSA-w5p7-h5w8-2hfq