### PR TITLE
Fix high vulnerability on trim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-out",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -189,9 +189,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "object-inspect": {
@@ -319,9 +319,9 @@
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/trim/-/trim-1.0.1.tgz",
+      "integrity": "sha512-3JVP2YVqITUisXblCDq/Bi4P9457G/sdEamInkyvCsjbTcXLXIiG7XCb4kGMFWh6JGXesS3TKxOPtrncN/xe8w=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "re-emitter": "1.1.3",
     "readable-stream": "2.2.9",
     "split": "1.0.0",
-    "trim": "0.0.1"
+    "trim": "^1.0.1"
   },
   "devDependencies": {
     "tape": "4.6.3"


### PR DESCRIPTION
Hi, this is a quick update on dependency to fix `npm audit`:
```              
                       === npm audit security report ===                        
                                                                                
# Run  npm install trim@1.0.1  to resolve 1 vulnerability
SEMVER WARNING: Recommended action is a potentially breaking change
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ High          │ Regular Expression Denial of Service in trim                 │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ trim                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ trim                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ trim                                                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1700                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


# Run  npm update minimist --depth 2  to resolve 1 vulnerability
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Low           │ Prototype Pollution                                          │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ minimist                                                     │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ tape [dev]                                                   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ tape > minimist                                              │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/1179                            │
└───────────────┴──────────────────────────────────────────────────────────────┘


found 2 vulnerabilities (1 low, 1 high) in 43 scanned packages
  run `npm audit fix` to fix 1 of them.
  1 vulnerability requires semver-major dependency updates.
```

I ran `npm t` and found no error.

 Please merge, please. :)