### PR TITLE
Fix parsing the error message output by ava --tap

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+index.js

--- a/index.js
+++ b/index.js
@@ -106,7 +106,6 @@ Parser.prototype.handleLine = function handleLine(line) {
 
 Parser.prototype._handleError = function _handleError(line) {
   var lastAssert;
-
   // Start of error output
   if (isErrorOutputStart(line)) {
     this.writingErrorOutput = true;
@@ -187,7 +186,7 @@ Parser.prototype._handleError = function _handleError(line) {
       lastAssert.error[this.currentNextLineError] = trim(line);
       this.currentNextLineError = null;
     }
-    else if (trim(m[1]) === '|-') {
+    else if (trim(m.at(-1)) === '|-' || trim(m.at(-1)) === '>-') {
       this.currentNextLineError = m[0];
     }
     else {

--- a/index.js
+++ b/index.js
@@ -155,9 +155,10 @@ Parser.prototype._handleError = function _handleError(line) {
       // Example string: Object.async.eachSeries (/Users/scott/www/modules/nash/node_modules/async/lib/async.js:145:20)
 
       msg = msg
+      .split(' ')[1] ? msg
       .split(' ')[1]
       .replace('(', '')
-      .replace(')', '');
+      .replace(')', '') : msg;
 
       var values = msg.split(':');
       var file = values.slice(0, values.length-2).join(':');

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "tap-out",
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-out",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "A different tap parser",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tap-out",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A different tap parser",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -650,6 +650,45 @@ test('handles multiline error stack with |-', function (t) {
 
 });
 
+test.only('handles error stack with |-', function (t) {
+
+  t.plan(2);
+
+  var mockTap = [
+    "TAP version 13",
+    "# promise error",
+    "not ok 1 TypeError: foo",
+    "  ---",
+    "    name: AssertionError",
+    "    assertion: 'true'",
+    "    at: 'internal/process/next_tick.js:103:7'",
+    "  ...",
+    "",
+    "1..1",
+    "# tests 1",
+    "# pass  0",
+    "# fail  1"
+  ];
+
+  var p = parser();
+
+  p.on('output', function (output) {
+    var assert = output.fail[0];
+    t.equal(assert.ok, false);
+    t.looseEqual(assert.error.at, {
+        character: '7',
+        file: 'internal/process/next_tick.js',
+        line: '103'
+    });
+  });
+
+  mockTap.forEach(function (line) {
+    p.write(line + '\n');
+  });
+  p.end();
+
+});
+
 test('output without plan', function (t) {
 
   t.plan(1);

--- a/test/index.js
+++ b/test/index.js
@@ -650,7 +650,7 @@ test('handles multiline error stack with |-', function (t) {
 
 });
 
-test.only('handles error stack with |-', function (t) {
+test('handles error stack with function that has no name', function (t) {
 
   t.plan(2);
 
@@ -680,6 +680,47 @@ test.only('handles error stack with |-', function (t) {
         file: 'internal/process/next_tick.js',
         line: '103'
     });
+  });
+
+  mockTap.forEach(function (line) {
+    p.write(line + '\n');
+  });
+  p.end();
+
+});
+
+test('handles error stack with multiple error function lines', function (t) {
+
+  t.plan(2);
+
+  var mockTap = [
+    "TAP version 13",
+    "# promise error",
+    "not ok 1 TypeError: foo",
+    "  ---",
+    "    name: AssertionError",
+    "    message: Rejected promise returned by test",
+    "    assertion: 'true'",
+    "    values:",
+    "     'Rejected promise returned by test. Reason:': |-",
+    "       Error {",
+    "         message: 'expected 200 \"OK\", got 301 \"Moved Permanently\"',",
+    "       }",
+    "    at: >-",
+    "     integration_tests/ava_apiV3Tests.js:116:4",
+    "  ...",
+    "",
+    "1..1",
+    "# tests 1",
+    "# pass  0",
+    "# fail  1"
+  ];
+
+  var p = parser();
+
+  p.on('output', function (output) {
+    var assert = output.fail[0];
+    t.equal(assert.ok, false);
   });
 
   mockTap.forEach(function (line) {


### PR DESCRIPTION
This is a patch to fix parsing the failed test output by our AVA test runner with `--tap`.   
The command we used is like this: `ava integration_tests/ava_*.js --tap |  tap-tc`

*`tap-tc` is this lib: https://github.com/zacanger/tap-tc*

The returned result is like this:
```
TAP version 13
# before hook
ok 1 - be able HTTP get /ping
not ok 2 - get one item
  ---
    name: AssertionError
    message: Rejected promise returned by test
    values:
      'Rejected promise returned by test. Reason:': |-
        Error {
          message: 'expected 200 "OK", got 301 "Moved Permanently"',
        }
    at: >-
      integration_tests/ava_apiV3Tests.js:116:4

      ----

      Test._assertStatus (node_modules/supertest/lib/test.js:304:12)

      node_modules/supertest/lib/test.js:80:15

      Test._assertFunction (node_modules/supertest/lib/test.js:338:11)

      Test.assert (node_modules/supertest/lib/test.js:209:21)

      localAssert (node_modules/supertest/lib/test.js:167:12)

      fn (node_modules/supertest/lib/test.js:164:5)

      Test.callback
      (node_modules/supertest/node_modules/superagent/src/node/index.js:902:3)

      IncomingMessage.<anonymous>
      (node_modules/supertest/node_modules/superagent/src/node/index.js:1130:18)
  ...
# after.always hook

1..2
# tests 2
# pass 1
# fail 1
```